### PR TITLE
修正 typo

### DIFF
--- a/include/templates.tex
+++ b/include/templates.tex
@@ -43,7 +43,7 @@
     \begin{itemize}
       \item APS 官网 \link{https://journals.aps.org/revtex}
       \item \TeX{} Live 自带（注意检查版本）
-      \item 阅读文档：|textdoc aps|
+      \item 阅读文档：|texdoc aps|
     \end{itemize}
 
   \item<+-> 写作


### PR DESCRIPTION
多了一个字母。

此外，`examples/apssamp.pdf` 似乎并不存在……